### PR TITLE
ESLint config: relax unused-vars for vars following _ pattern

### DIFF
--- a/eslint/.eslintrc.js
+++ b/eslint/.eslintrc.js
@@ -152,6 +152,15 @@ module.exports = {
 
         // Typescript specific rules
         "@typescript-eslint/no-explicit-any": "off",
-        "@typescript-eslint/no-require-imports": "warn"
+        "@typescript-eslint/no-require-imports": "warn",
+        "@typescript-eslint/no-unused-vars": ["warn", {
+            // ignore unused vars when named one or more _
+            "varsIgnorePattern": "^_*$",
+            "argsIgnorePattern": "^_*$",
+            "caughtErrorsIgnorePattern": "^_*$", 
+
+            // for cases like this const { unused, ...rest } = props
+            "ignoreRestSiblings": true,
+        }]
     }
 }

--- a/eslint/.eslintrc.json
+++ b/eslint/.eslintrc.json
@@ -155,6 +155,17 @@
             }
         ],
         "@typescript-eslint/no-explicit-any": "off",
-        "@typescript-eslint/no-require-imports": "warn"
+        "@typescript-eslint/no-require-imports": "warn",
+        "@typescript-eslint/no-unused-vars": [
+            "warn",
+            {
+                // ignore unused vars when named one or more _
+                "varsIgnorePattern": "^_*$",
+                "argsIgnorePattern": "^_*$",
+                "caughtErrorsIgnorePattern": "^_*$",
+                // for cases like this const { unused, ...rest } = props
+                "ignoreRestSiblings": true
+            }
+        ]
     }
 }


### PR DESCRIPTION
Add config to allow unused vars named after a certain pattern to be excluded from the unused vars directive
Prevents having to add the eslint-disable directive and allows for more flexibility
