### PR TITLE
Add Gnome terminal profiles

### DIFF
--- a/gnome-terminal/README.md
+++ b/gnome-terminal/README.md
@@ -1,0 +1,7 @@
+# Gnome terminal profiles
+
+Gnome terminal manages it's configurations by using profiles.
+
+Profiles are a set of configurations related to visual aspects of the terminal and can be represented via a config file.
+
+Use the [loading script](load-profiles.sh) to load the profiles in the config file([gnome-terminal-profiles.dconf](./gnome-terminal-profiles.dconf)) and make them available in the terminal preferences

--- a/gnome-terminal/gnome-terminal-profiles.dconf
+++ b/gnome-terminal/gnome-terminal-profiles.dconf
@@ -1,0 +1,17 @@
+[:b1dcc9dd-5262-4d8d-a863-c897e6d979b9]
+audible-bell=false
+background-color='rgb(255,255,221)'
+background-transparency-percent=17
+bold-is-bright=false
+cursor-blink-mode='on'
+cursor-shape='underline'
+font='Ubuntu Mono 12'
+foreground-color='rgb(0,0,0)'
+login-shell=true
+palette=['rgb(46,52,54)', 'rgb(204,0,0)', 'rgb(78,154,6)', 'rgb(196,160,0)', 'rgb(52,101,164)', 'rgb(117,80,123)', 'rgb(6,152,154)', 'rgb(211,215,207)', 'rgb(85,87,83)', 'rgb(239,41,41)', 'rgb(138,226,52)', 'rgb(252,233,79)', 'rgb(114,159,207)', 'rgb(173,127,168)', 'rgb(52,226,226)', 'rgb(238,238,236)']
+text-blink-mode='focused'
+use-system-font=true
+use-theme-colors=true
+use-theme-transparency=true
+use-transparent-background=false
+visible-name='Ubuntu 16 like'

--- a/gnome-terminal/load-profiles.sh
+++ b/gnome-terminal/load-profiles.sh
@@ -1,0 +1,1 @@
+dconf load /org/gnome/terminal/legacy/profiles:/ < gnome-terminal-profiles.dconf


### PR DESCRIPTION
Add an extendable config file with the configurations for a profile that makes the terminal look like it was in Ubuntu 16.04

Also adds a loading script to avoid having to always remember the loading command in the future and a README.md explaining this