### PR TITLE
Remove annoying NPM warning about optional directive deprecation

### DIFF
--- a/npm/.npmrc
+++ b/npm/.npmrc
@@ -1,6 +1,9 @@
 # Turn off packages that need funding message
 fund=false 
-optional=true
-save-optional=false 
+
+# Don't automatically install optional or peer dependencies 
+omit=optional
+omit=peer
+
 # Save dependencies as exact versions
 save-exact=true


### PR DESCRIPTION
It produces an annoying warning on npm >= 8.9.0